### PR TITLE
Code linting for Ace editor

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -32,6 +32,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 	<script src="js/theme-monokai.js" type="text/javascript" charset="utf-8"></script>
 	<script src="js/theme-eclipse.js" type="text/javascript" charset="utf-8"></script>
     <script src="js/ace.js" type="text/javascript" charset="utf-8"></script>
+    <script src="https://www.unpkg.com/ace-linters@0.10.3/build/ace-linters.js"></script>
     <script src="js/FileSaver.min.js" type="text/javascript" charset="utf-8"></script>
     <script src="js/split.min.js" type="text/javascript" charset="utf-8"></script>
 

--- a/js/editor.js
+++ b/js/editor.js
@@ -898,10 +898,12 @@ var editor = ace.edit("editor");
   );
 
   provider.setGlobalOptions("python", {
+	// Ruff custom configurations
+	// https://beta.ruff.rs/docs/settings/
+	  configuration: {
+		  builtins: ["label", "goto", "forever", "clear"] // etc.
+		},
 	// Flake8 Errors to support common Introduction to Coding Syntax
-	configuration: {
-		builtins: ["label", "goto", "forever", "clear"] // etc.
-    },
     errorCodesToIgnore: [
         "F403", // import *
 		"F405" // possibly undefined name from import *

--- a/js/editor.js
+++ b/js/editor.js
@@ -899,11 +899,15 @@ var editor = ace.edit("editor");
 
   provider.setGlobalOptions("python", {
 	// Flake8 Errors to support common Introduction to Coding Syntax
+	configuration: {
+		builtins: ["label", "goto", "forever", "clear"] // etc.
+    },
     errorCodesToIgnore: [
-        "E501", // lines > 80 char
         "F403", // import *
-		"F821", // undefined name e.g. "goto"
 		"F405" // possibly undefined name from import *
+    ],
+    errorCodesToTreatAsWarning: [
+        "E501", // lines > 80 char
     ],
 });
   provider.registerEditor(editor);

--- a/js/editor.js
+++ b/js/editor.js
@@ -889,6 +889,24 @@ checkBrowser();
 var pyConsole = document.getElementById("console");
 
 var editor = ace.edit("editor");
+	// This adds a 3mb gzipped file for the Ruff linter
+	// https://github.com/charliermarsh/ruff
+	// Not sure how you could make this async to still run the editor
+	// while this is downloading.
+  var provider = LanguageProvider.fromCdn(
+	"https://www.unpkg.com/ace-linters@0.10.3/build/"
+  );
+
+  provider.setGlobalOptions("python", {
+	// Flake8 Errors to support common Introduction to Coding Syntax
+    errorCodesToIgnore: [
+        "E501", // lines > 80 char
+        "F403", // import *
+		"F821", // undefined name e.g. "goto"
+		"F405" // possibly undefined name from import *
+    ],
+});
+  provider.registerEditor(editor);
 var darkTheme = true;
 editor.setTheme("ace/theme/monokai");
 editor.session.setMode("ace/mode/python");


### PR DESCRIPTION
**_For discussion not for merging_**

A proof of concept to add linting into the Ace Editor built in to CS in Schools.
Below I've listed a range of user stories, a process I have at my current company to define the possible needs for a feature framing it from the perspective of the users of the feature. Fully aware that this only makes assumption of how linting helps or hinders teaching coding, so keen for feedback.

# User Story

- [ ] As a student making common syntax errors (e.g. "String not surrounded by quotes"), I'd expect to be notified of the error before I type too many other things.
- [ ] As a teacher having an initially broken example problem, I might not want the whole thing to light up with errors. e.g. [coding-task-01-02-hello-world](https://csinschools.io/courses/introduction-to-coding/lessons/lesson-1-welcome-to-cs-in-schools/activities/coding-task-01-02-hello-world/)
- [ ] As a teacher creating content for student, I'd expect I could go faster if I could get quick feedback about errors (even if its a hidden feature)
- [ ] As a csinschools developer with lots of custom builtins, I'd expect the linter can be programmed to ignore these. e.g. `goto`, `clear`.
- [ ] As a student on "trainingWheels" mode, I'd expect the linter can be turned off to not give me erroneous messages

# Screenshot
<img width="1032" alt="image" src="https://github.com/csinschools/editor/assets/58811856/3c0fb2c2-ce1a-4448-a410-564cd9a76e9a">


# Video

https://github.com/csinschools/editor/assets/58811856/f23af842-9198-470b-90c4-bbb043424816

